### PR TITLE
use boost::placeholders::_N instead of deprecated global namespace _N

### DIFF
--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -1,6 +1,6 @@
 #include "async_web_server_cpp/http_reply.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/make_shared.hpp>
 
 namespace async_web_server_cpp
@@ -21,7 +21,7 @@ boost::asio::ip::tcp::socket& HttpConnection::socket()
 void HttpConnection::start()
 {
     async_read(
-        boost::bind(&HttpConnection::handle_read, shared_from_this(), _1, _2));
+        boost::bind(&HttpConnection::handle_read, shared_from_this(), boost::placeholders::_1, boost::placeholders::_2));
 }
 
 void HttpConnection::handle_read(const char* begin, const char* end)
@@ -52,7 +52,7 @@ void HttpConnection::handle_read(const char* begin, const char* end)
     else
     {
         async_read(boost::bind(&HttpConnection::handle_read, shared_from_this(),
-                               _1, _2));
+                               boost::placeholders::_1, boost::placeholders::_2));
     }
 }
 

--- a/src/http_request_handler.cpp
+++ b/src/http_request_handler.cpp
@@ -3,7 +3,7 @@
 #include "async_web_server_cpp/http_connection.hpp"
 #include "async_web_server_cpp/http_reply.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/regex.hpp>
@@ -119,7 +119,7 @@ public:
         {
             connection_->async_read(
                 boost::bind(&BodyCollectingConnection::static_handle_read,
-                            shared_from_this(), _1, _2));
+                            shared_from_this(), boost::placeholders::_1, boost::placeholders::_2));
         }
     }
 

--- a/src/websocket_connection.cpp
+++ b/src/websocket_connection.cpp
@@ -1,6 +1,6 @@
 #include "async_web_server_cpp/websocket_connection.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/make_shared.hpp>
 
 #include <limits>
@@ -89,7 +89,7 @@ void WebsocketConnection::handle_read(const char* begin, const char* end)
     }
     WebsocketConnectionWeakPtr this_weak(shared_from_this());
     connection_->async_read(boost::bind(
-        &WebsocketConnection::static_handle_read, this_weak, _1, _2));
+        &WebsocketConnection::static_handle_read, this_weak, boost::placeholders::_1, boost::placeholders::_2));
 }
 
 }  // namespace async_web_server_cpp


### PR DESCRIPTION
This gets rid of a deprecation warning while compiling