### PR TITLE
Fix to build with current Boost libraries

### DIFF
--- a/include/async_web_server_cpp/http_connection.hpp
+++ b/include/async_web_server_cpp/http_connection.hpp
@@ -10,6 +10,7 @@
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/array.hpp>
 
 namespace async_web_server_cpp
 {

--- a/src/http_reply.cpp
+++ b/src/http_reply.cpp
@@ -360,9 +360,9 @@ bool FilesystemHttpRequestHandler::operator()(
                         if (boost::filesystem::is_directory(itr->status()))
                         {
                             content << "<a href=\""
-                                    << itr->path().leaf().generic_string()
+                                    << itr->path().filename().generic_string()
                                     << "/\">";
-                            content << itr->path().leaf().generic_string()
+                            content << itr->path().filename().generic_string()
                                     << "/";
                             content << "</a>";
                         }
@@ -370,9 +370,9 @@ bool FilesystemHttpRequestHandler::operator()(
                                      itr->status()))
                         {
                             content << "<a href=\""
-                                    << itr->path().leaf().generic_string()
+                                    << itr->path().filename().generic_string()
                                     << "\">";
-                            content << itr->path().leaf().generic_string();
+                            content << itr->path().filename().generic_string();
                             content << "</a>";
                         }
                         content << "<br>";


### PR DESCRIPTION
Adding array include to include/async_web_server_cpp/http_connection.hpp Boost class path member leaf is now replaced with filename, see https://github.com/boostorg/filesystem/commit/5df060e95ca844fe91b29001b4ae22bdb65635c6

See issue: https://github.com/fkie/async_web_server_cpp/issues/6