### PR TITLE
Fix compile errors with Boost >= 1.87

### DIFF
--- a/include/async_web_server_cpp/http_connection.hpp
+++ b/include/async_web_server_cpp/http_connection.hpp
@@ -40,7 +40,7 @@ public:
         ReadHandler;
     typedef std::shared_ptr<const void> ResourcePtr;
 
-    explicit HttpConnection(boost::asio::io_service& io_service,
+    explicit HttpConnection(boost::asio::io_context& io_service,
                             HttpServerRequestHandler request_handler);
 
     boost::asio::ip::tcp::socket& socket();
@@ -79,7 +79,7 @@ private:
     void handle_write(const boost::system::error_code& e,
                       std::vector<ResourcePtr> resources);
 
-    boost::asio::io_service::strand strand_;
+    boost::asio::io_context::strand strand_;
     boost::asio::ip::tcp::socket socket_;
     HttpServerRequestHandler request_handler_;
     boost::array<char, 8192> buffer_;

--- a/include/async_web_server_cpp/http_server.hpp
+++ b/include/async_web_server_cpp/http_server.hpp
@@ -40,7 +40,7 @@ private:
 
     void handle_accept(const boost::system::error_code& e);
 
-    boost::asio::io_service io_service_;
+    boost::asio::io_context io_service_;
     boost::asio::ip::tcp::acceptor acceptor_;
     std::size_t thread_pool_size_;
     std::vector<boost::shared_ptr<boost::thread>> threads_;

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -6,7 +6,7 @@
 namespace async_web_server_cpp
 {
 
-HttpConnection::HttpConnection(boost::asio::io_service& io_service,
+HttpConnection::HttpConnection(boost::asio::io_context& io_service,
                                HttpServerRequestHandler handler)
     : strand_(io_service), socket_(io_service), request_handler_(handler),
       write_in_progress_(false)

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -13,9 +13,7 @@ HttpServer::HttpServer(const std::string& address, const std::string& port,
 {
 
     boost::asio::ip::tcp::resolver resolver(io_service_);
-    boost::asio::ip::tcp::resolver::query query(
-        address, port, boost::asio::ip::resolver_query_base::flags());
-    boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(query);
+    boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(address, port).begin();
     acceptor_.open(endpoint.protocol());
     acceptor_.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
     acceptor_.bind(endpoint);
@@ -33,7 +31,7 @@ void HttpServer::run()
     for (std::size_t i = 0; i < thread_pool_size_; ++i)
     {
         boost::shared_ptr<boost::thread> thread(new boost::thread(
-            boost::bind(&boost::asio::io_service::run, &io_service_)));
+            boost::bind(&boost::asio::io_context::run, &io_service_)));
         threads_.push_back(thread);
     }
 }


### PR DESCRIPTION
That release removed many deprecated features. See https://www.boost.org/doc/libs/latest/doc/html/boost_asio/history.html#boost_asio.history.asio_1_33_0

Typical error message looks like this:

    In file included from /build/async_web_server_cpp-release-release-jazzy-async_web_server_cpp-2.0.1-1/include/async_web_server_cpp/websocket_connection.hpp:4,
                     from /build/async_web_server_cpp-release-release-jazzy-async_web_server_cpp-2.0.1-1/src/websocket_connection.cpp:1:
    /build/async_web_server_cpp-release-release-jazzy-async_web_server_cpp-2.0.1-1/include/async_web_server_cpp/http_connection.hpp:43:52: error: expected ')' before '&' token
       43 |     explicit HttpConnection(boost::asio::io_service& io_service,
          |                            ~                       ^
          |                                                    )
    /build/async_web_server_cpp-release-release-jazzy-async_web_server_cpp-2.0.1-1/include/async_web_server_cpp/http_connection.hpp:82:18: error: 'io_service' in namespace 'boost::asio' does not name a type; did you mean 'use_service'?
       82 |     boost::asio::io_service::strand strand_;
          |                  ^~~~~~~~~~
          |                  use_service

Test suite passes.