### PR TITLE
Update Asio strand usage

### DIFF
--- a/include/async_web_server_cpp/http_connection.hpp
+++ b/include/async_web_server_cpp/http_connection.hpp
@@ -79,7 +79,7 @@ private:
     void handle_write(const boost::system::error_code& e,
                       std::vector<ResourcePtr> resources);
 
-    boost::asio::io_context::strand strand_;
+    boost::asio::strand<boost::asio::io_context::executor_type> strand_;
     boost::asio::ip::tcp::socket socket_;
     HttpServerRequestHandler request_handler_;
     boost::array<char, 8192> buffer_;

--- a/src/http_connection.cpp
+++ b/src/http_connection.cpp
@@ -8,7 +8,7 @@ namespace async_web_server_cpp
 
 HttpConnection::HttpConnection(boost::asio::io_context& io_service,
                                HttpServerRequestHandler handler)
-    : strand_(io_service), socket_(io_service), request_handler_(handler),
+    : strand_(io_service.get_executor()), socket_(io_service), request_handler_(handler),
       write_in_progress_(false)
 {
 }
@@ -77,7 +77,8 @@ void HttpConnection::async_read(ReadHandler callback)
     }
     socket_.async_read_some(
         boost::asio::buffer(buffer_),
-        strand_.wrap(
+        boost::asio::bind_executor(
+            strand_,
             boost::bind(&HttpConnection::handle_read_raw, shared_from_this(),
                         callback, boost::asio::placeholders::error,
                         boost::asio::placeholders::bytes_transferred)));

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -13,7 +13,7 @@ HttpServer::HttpServer(const std::string& address, const std::string& port,
 {
 
     boost::asio::ip::tcp::resolver resolver(io_service_);
-    boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(address, port).begin();
+    boost::asio::ip::tcp::endpoint endpoint = resolver.resolve(address, port).begin()->endpoint();
     acceptor_.open(endpoint.protocol());
     acceptor_.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
     acceptor_.bind(endpoint);


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack patch/ros-rolling-async-web-server-cpp.patch, authored by Antoine Van Malleghem.

The upstream branch already uses boost::asio::io_context, so the remaining build fix is to use the modern strand executor form, boost::asio::bind_executor, and the current resolver result API. This keeps the change focused on compatibility with newer Boost.Asio without reintroducing older io_service compatibility code.